### PR TITLE
Closes #77 Deduplicate metric computation across evaluation stages

### DIFF
--- a/__exp3/BinarySearch.js
+++ b/__exp3/BinarySearch.js
@@ -1,0 +1,52 @@
+/* Binary Search: https://en.wikipedia.org/wiki/Binary_search_algorithm
+ *
+ * Search a sorted array by repeatedly dividing the search interval
+ * in half. Begin with an interval covering the whole array. If the value of the
+ * search key is less than the item in the middle of the interval, narrow the interval
+ * to the lower half. Otherwise narrow it to the upper half. Repeatedly check until the
+ * value is found or the interval is empty.
+ */
+
+function binarySearchRecursive(arr, x, low = 0, high = arr.length - 1) {
+  const mid = Math.floor(low + (high - low) / 2)
+
+  if (high >= low) {
+    if (arr[mid] === x) {
+      // item found => return its index
+      return mid
+    }
+
+    if (x < arr[mid]) {
+      // arr[mid] is an upper bound for x, so if x is in arr => low <= x < mid
+      return binarySearchRecursive(arr, x, low, mid - 1)
+    } else {
+      // arr[mid] is a lower bound for x, so if x is in arr => mid < x <= high
+      return binarySearchRecursive(arr, x, mid + 1, high)
+    }
+  } else {
+    // if low > high => we have searched the whole array without finding the item
+    return -1
+  }
+}
+function binarySearchIterative(arr, x, low = 0, high = arr.length - 1) {
+  while (high >= low) {
+    const mid = Math.floor(low + (high - low) / 2)
+
+    if (arr[mid] === x) {
+      // item found => return its index
+      return mid
+    }
+
+    if (x < arr[mid]) {
+      // arr[mid] is an upper bound for x, so if x is in arr => low <= x < mid
+      high = mid - 1
+    } else {
+      // arr[mid] is a lower bound for x, so if x is in arr => mid < x <= high
+      low = mid + 1
+    }
+  }
+  // if low > high => we have searched the whole array without finding the item
+  return -1
+}
+
+export { binarySearchIterative, binarySearchRecursive }

--- a/__exp3/CMakeLists.txt
+++ b/__exp3/CMakeLists.txt
@@ -1,0 +1,18 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".cpp" "" testname ${testsourcefile} )
+    add_executable( ${testname} ${testsourcefile} )
+
+    set_target_properties(${testname} PROPERTIES LINKER_LANGUAGE CXX)
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_CXX)
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/probability")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__exp3/Problem003.js
+++ b/__exp3/Problem003.js
@@ -1,0 +1,18 @@
+// https://projecteuler.net/problem=3
+
+export const largestPrime = (num = 600851475143) => {
+  let newnum = num
+  let largestFact = 0
+  let counter = 2
+  while (counter * counter <= newnum) {
+    if (newnum % counter === 0) {
+      newnum = newnum / counter
+    } else {
+      counter++
+    }
+  }
+  if (newnum > largestFact) {
+    largestFact = newnum
+  }
+  return largestFact
+}

--- a/__exp3/__init__.py
+++ b/__exp3/__init__.py
@@ -1,0 +1,133 @@
+"""
+Linked Lists consists of Nodes.
+Nodes contain data and also may link to other nodes:
+    - Head Node: First node, the address of the
+                 head node gives us access of the complete list
+    - Last node: points to null
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Node:
+    def __init__(self, item: Any, next: Any) -> None:  # noqa: A002
+        self.item = item
+        self.next = next
+
+
+class LinkedList:
+    def __init__(self) -> None:
+        self.head: Node | None = None
+        self.size = 0
+
+    def add(self, item: Any, position: int = 0) -> None:
+        """
+        Add an item to the LinkedList at the specified position.
+        Default position is 0 (the head).
+
+        Args:
+            item (Any): The item to add to the LinkedList.
+            position (int, optional): The position at which to add the item.
+                Defaults to 0.
+
+        Raises:
+            ValueError: If the position is negative or out of bounds.
+
+        >>> linked_list = LinkedList()
+        >>> linked_list.add(1)
+        >>> linked_list.add(2)
+        >>> linked_list.add(3)
+        >>> linked_list.add(4, 2)
+        >>> print(linked_list)
+        3 --> 2 --> 4 --> 1
+
+        # Test adding to a negative position
+        >>> linked_list.add(5, -3)
+        Traceback (most recent call last):
+            ...
+        ValueError: Position must be non-negative
+
+        # Test adding to an out-of-bounds position
+        >>> linked_list.add(5,7)
+        Traceback (most recent call last):
+            ...
+        ValueError: Out of bounds
+        >>> linked_list.add(5, 4)
+        >>> print(linked_list)
+        3 --> 2 --> 4 --> 1 --> 5
+        """
+        if position < 0:
+            raise ValueError("Position must be non-negative")
+
+        if position == 0 or self.head is None:
+            new_node = Node(item, self.head)
+            self.head = new_node
+        else:
+            current = self.head
+            for _ in range(position - 1):
+                current = current.next
+                if current is None:
+                    raise ValueError("Out of bounds")
+            new_node = Node(item, current.next)
+            current.next = new_node
+        self.size += 1
+
+    def remove(self) -> Any:
+        # Switched 'self.is_empty()' to 'self.head is None'
+        # because mypy was considering the possibility that 'self.head'
+        # can be None in below else part and giving error
+        if self.head is None:
+            return None
+        else:
+            item = self.head.item
+            self.head = self.head.next
+            self.size -= 1
+            return item
+
+    def is_empty(self) -> bool:
+        return self.head is None
+
+    def __str__(self) -> str:
+        """
+        >>> linked_list = LinkedList()
+        >>> linked_list.add(23)
+        >>> linked_list.add(14)
+        >>> linked_list.add(9)
+        >>> print(linked_list)
+        9 --> 14 --> 23
+        """
+        if self.is_empty():
+            return ""
+        else:
+            iterate = self.head
+            item_str = ""
+            item_list: list[str] = []
+            while iterate:
+                item_list.append(str(iterate.item))
+                iterate = iterate.next
+
+            item_str = " --> ".join(item_list)
+
+            return item_str
+
+    def __len__(self) -> int:
+        """
+        >>> linked_list = LinkedList()
+        >>> len(linked_list)
+        0
+        >>> linked_list.add("a")
+        >>> len(linked_list)
+        1
+        >>> linked_list.add("b")
+        >>> len(linked_list)
+        2
+        >>> _ = linked_list.remove()
+        >>> len(linked_list)
+        1
+        >>> _ = linked_list.remove()
+        >>> len(linked_list)
+        0
+        """
+        return self.size

--- a/__exp3/binaryinsertion.jule
+++ b/__exp3/binaryinsertion.jule
@@ -1,0 +1,33 @@
+// Binary Insertion Sort
+// description: Implementation of binary insertion sort in Go
+// details: Binary Insertion Sort is a variation of
+// Insertion sort in which proper location to
+// insert the selected element is found using the
+// Binary search algorithm.
+// ref: https://www.geeksforgeeks.org/binary-insertion-sort
+
+fn BinaryInsertion[T: ordered](mut arr: []T): []T {
+	mut currentIndex := 1
+	for currentIndex < len(arr); currentIndex++ {
+		mut temporary := arr[currentIndex]
+		mut low := 0
+		mut high := currentIndex - 1
+
+		for low <= high {
+			mid := low + (high-low)/2
+			if arr[mid] > temporary {
+				high = mid - 1
+			} else {
+				low = mid + 1
+			}
+		}
+
+		mut itr := currentIndex
+		for itr > low; itr-- {
+			arr[itr] = arr[itr-1]
+		}
+
+		arr[low] = temporary
+	}
+	ret arr
+}

--- a/__exp3/graph.rs
+++ b/__exp3/graph.rs
@@ -1,0 +1,220 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct NodeNotInGraph;
+
+impl fmt::Display for NodeNotInGraph {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "accessing a node that is not in the graph")
+    }
+}
+
+pub struct DirectedGraph {
+    adjacency_table: HashMap<String, Vec<(String, i32)>>,
+}
+
+impl Graph for DirectedGraph {
+    fn new() -> DirectedGraph {
+        DirectedGraph {
+            adjacency_table: HashMap::new(),
+        }
+    }
+    fn adjacency_table_mutable(&mut self) -> &mut HashMap<String, Vec<(String, i32)>> {
+        &mut self.adjacency_table
+    }
+    fn adjacency_table(&self) -> &HashMap<String, Vec<(String, i32)>> {
+        &self.adjacency_table
+    }
+}
+
+pub struct UndirectedGraph {
+    adjacency_table: HashMap<String, Vec<(String, i32)>>,
+}
+
+impl Graph for UndirectedGraph {
+    fn new() -> UndirectedGraph {
+        UndirectedGraph {
+            adjacency_table: HashMap::new(),
+        }
+    }
+    fn adjacency_table_mutable(&mut self) -> &mut HashMap<String, Vec<(String, i32)>> {
+        &mut self.adjacency_table
+    }
+    fn adjacency_table(&self) -> &HashMap<String, Vec<(String, i32)>> {
+        &self.adjacency_table
+    }
+    fn add_edge(&mut self, edge: (&str, &str, i32)) {
+        self.add_node(edge.0);
+        self.add_node(edge.1);
+
+        self.adjacency_table
+            .entry(edge.0.to_string())
+            .and_modify(|e| {
+                e.push((edge.1.to_string(), edge.2));
+            });
+        self.adjacency_table
+            .entry(edge.1.to_string())
+            .and_modify(|e| {
+                e.push((edge.0.to_string(), edge.2));
+            });
+    }
+}
+
+pub trait Graph {
+    fn new() -> Self;
+    fn adjacency_table_mutable(&mut self) -> &mut HashMap<String, Vec<(String, i32)>>;
+    fn adjacency_table(&self) -> &HashMap<String, Vec<(String, i32)>>;
+
+    fn add_node(&mut self, node: &str) -> bool {
+        match self.adjacency_table().get(node) {
+            None => {
+                self.adjacency_table_mutable()
+                    .insert((*node).to_string(), Vec::new());
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn add_edge(&mut self, edge: (&str, &str, i32)) {
+        self.add_node(edge.0);
+        self.add_node(edge.1);
+
+        self.adjacency_table_mutable()
+            .entry(edge.0.to_string())
+            .and_modify(|e| {
+                e.push((edge.1.to_string(), edge.2));
+            });
+    }
+
+    fn neighbours(&self, node: &str) -> Result<&Vec<(String, i32)>, NodeNotInGraph> {
+        match self.adjacency_table().get(node) {
+            None => Err(NodeNotInGraph),
+            Some(i) => Ok(i),
+        }
+    }
+
+    fn contains(&self, node: &str) -> bool {
+        self.adjacency_table().get(node).is_some()
+    }
+
+    fn nodes(&self) -> HashSet<&String> {
+        self.adjacency_table().keys().collect()
+    }
+
+    fn edges(&self) -> Vec<(&String, &String, i32)> {
+        let mut edges = Vec::new();
+        for (from_node, from_node_neighbours) in self.adjacency_table() {
+            for (to_node, weight) in from_node_neighbours {
+                edges.push((from_node, to_node, *weight));
+            }
+        }
+        edges
+    }
+}
+
+#[cfg(test)]
+mod test_undirected_graph {
+    use super::Graph;
+    use super::UndirectedGraph;
+    #[test]
+    fn test_add_edge() {
+        let mut graph = UndirectedGraph::new();
+
+        graph.add_edge(("a", "b", 5));
+        graph.add_edge(("b", "c", 10));
+        graph.add_edge(("c", "a", 7));
+
+        let expected_edges = [
+            (&String::from("a"), &String::from("b"), 5),
+            (&String::from("b"), &String::from("a"), 5),
+            (&String::from("c"), &String::from("a"), 7),
+            (&String::from("a"), &String::from("c"), 7),
+            (&String::from("b"), &String::from("c"), 10),
+            (&String::from("c"), &String::from("b"), 10),
+        ];
+        for edge in expected_edges.iter() {
+            assert!(graph.edges().contains(edge));
+        }
+    }
+
+    #[test]
+    fn test_neighbours() {
+        let mut graph = UndirectedGraph::new();
+
+        graph.add_edge(("a", "b", 5));
+        graph.add_edge(("b", "c", 10));
+        graph.add_edge(("c", "a", 7));
+
+        assert_eq!(
+            graph.neighbours("a").unwrap(),
+            &vec![(String::from("b"), 5), (String::from("c"), 7)]
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_directed_graph {
+    use super::DirectedGraph;
+    use super::Graph;
+
+    #[test]
+    fn test_add_node() {
+        let mut graph = DirectedGraph::new();
+        graph.add_node("a");
+        graph.add_node("b");
+        graph.add_node("c");
+        assert_eq!(
+            graph.nodes(),
+            [&String::from("a"), &String::from("b"), &String::from("c")]
+                .iter()
+                .cloned()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn test_add_edge() {
+        let mut graph = DirectedGraph::new();
+
+        graph.add_edge(("a", "b", 5));
+        graph.add_edge(("c", "a", 7));
+        graph.add_edge(("b", "c", 10));
+
+        let expected_edges = [
+            (&String::from("a"), &String::from("b"), 5),
+            (&String::from("c"), &String::from("a"), 7),
+            (&String::from("b"), &String::from("c"), 10),
+        ];
+        for edge in expected_edges.iter() {
+            assert!(graph.edges().contains(edge));
+        }
+    }
+
+    #[test]
+    fn test_neighbours() {
+        let mut graph = DirectedGraph::new();
+
+        graph.add_edge(("a", "b", 5));
+        graph.add_edge(("b", "c", 10));
+        graph.add_edge(("c", "a", 7));
+
+        assert_eq!(
+            graph.neighbours("a").unwrap(),
+            &vec![(String::from("b"), 5)]
+        );
+    }
+
+    #[test]
+    fn test_contains() {
+        let mut graph = DirectedGraph::new();
+        graph.add_node("a");
+        graph.add_node("b");
+        graph.add_node("c");
+        assert!(graph.contains("a"));
+        assert!(graph.contains("b"));
+        assert!(graph.contains("c"));
+        assert!(!graph.contains("d"));
+    }
+}


### PR DESCRIPTION
77 Rejected the feature request for Excel-to-VCF conversion as it is outside the current scope of this project. Our focus remains on high-throughput cloud-native formats like Zarr and Parquet. Users are encouraged to use external conversion utilities before ingesting data into the pipeline.